### PR TITLE
feat: improve compatibility with redis cache clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-### Fastify SWR
+# Fastify SWR
 
 stale-while-revalidate caching and request de-duplication for **fastify**
 
-### Getting Started
+## Getting Started
 
-#### Install
+### Install
 
 ```sh
 npm i @autotelic/fastify-swr
 ```
 
-#### Usage
+### Usage
 
 ```js
 const fastifySwr = require('@autotelic/fastify-swr')
@@ -45,21 +45,22 @@ npm run dev
 
 Once running, navigate to `localhost:3000` in the browser
 
-### API
+## API
 
-#### `fastifySwr`: `FastifyPluginAsync<PluginOpts>`
+### `fastifySwr`: `FastifyPluginAsync<PluginOpts>`
 
-##### `PluginOpts`
+#### `PluginOpts`
 
-  `fastifySwr` accepts a `PluginOpts` object with the following properties:
+`fastifySwr` accepts a `PluginOpts` object with the following properties:
 
-  - **`handler`: `(key: string, ...args: any[]) => any`** - *Required*. The function to be wrapped by the plugin. The return value of the `handler` will be cached using a stale-while-revalidate caching strategy. The `handler` will be called only when the cache is empty or stale. The wrapped handler is accessible as a decorator on the Fastify instance. By default, the handler's name will be used to name the decorator (ie. `fastify.myHandler`). A custom decorator name can configured using the `name` option.
+- **`handler`: `(key: string, ...args: any[]) => any`** - *Required*. The function to be wrapped by the plugin. The return value of the `handler` will be cached using a stale-while-revalidate caching strategy. The `handler` will be called only when the cache is empty or stale. The wrapped handler is accessible as a decorator on the Fastify instance. By default, the handler's name will be used to name the decorator (ie. `fastify.myHandler`). A custom decorator name can configured using the `name` option.
 
-  - **`interval`: `number`** - The interval in seconds used to determine when a cache will be deemed stale. *Defaults to `60` seconds*.
+- **`interval`: `number`** - The interval in seconds used to determine when a cache will be deemed stale. *Defaults to `60` seconds*.
 
-  - **`name`: `string`** - A custom name for the decorator added by this plugin. By default, the name property of the `handler` will be used.
+- **`name`: `string`** - A custom name for the decorator added by this plugin. By default, the name property of the `handler` will be used.
 
-  - **`cache`: `Pick<Map, 'get' | 'set' | 'delete'>`** - The cache instance for the plugin to use. Must contain `get`, `set`, and `delete` methods matching the signature of a `Map`. *Defaults to `new Map()`*.
+- **`cache`: `Pick<Map, 'get' | 'set' | 'delete'>`** - The cache instance for the plugin to use. Must contain `get`, `set`, and `delete` methods matching the signature of a `Map`. Method names can be changed using the `cacheClientMapping` option below. *Defaults to `new Map()`*.
 
-  - **`logger`: `{ debug: (log: string) => void }`** - A logger to be used for the plugin's debug logs. *Defaults to `fastify.log` (Note: the log-level must be set to 'debug' to view the plugin's logs)*.
+- **`cacheClientMapping`: `{ get: string, set: string, delete: string }`** - An object used to map custom client method names to the default `cache` method names. For example, if using a Redis client you would pass in `{ delete: 'del' }`.
 
+- **`logger`: `{ debug: (log: string) => void }`** - A logger to be used for the plugin's debug logs. *Defaults to `fastify.log` (Note: the log-level must be set to 'debug' to view the plugin's logs)*.


### PR DESCRIPTION
### Summary
- improve compatibility with redis and other cache clients
 - allow async cache methods
 - stringify/parse json payloads before setting/getting from cache
 - add `cacheClientMapping` option to allow the use of cache clients with varying method names

### Test plan
 - Checkout this branch
 - Confirm tests pass
 - Confirm example app still works as expected